### PR TITLE
Add support for user-defined Fairness measures and user-defined Losses

### DIFF
--- a/src/fairgrad/fairness_functions.py
+++ b/src/fairgrad/fairness_functions.py
@@ -155,14 +155,9 @@ class EqualityOpportunity:
         y: npt.NDArray[int],
         s: npt.NDArray[int],
         y_desirable: npt.NDArray[int],
-    ):
+    ):      
         self.y_desirable = y_desirable
-        self.y_unique = y_unique
-        self.s_unique = s_unique
-        self.y = y
-        self.s = s
-        self.init_C(self.y, self.s)
-        self.init_P(self.y, self.s)
+        super().__init__(y_unique, s_unique, y, s)
 
     def init_C(self, y, s):
         n_groups = self.y_unique.shape[0] * self.s_unique.shape[0]
@@ -232,13 +227,13 @@ class DemographicParity(FairnessMeasure):
         y: npt.NDArray[int],
         s: npt.NDArray[int],
     ):
-        super().__init__(y_unique, s_unique, y, s)
         if y_unique.shape[0] != 2:
             raise ValueError(
                 "Demographic Parity is only applicable to binary problems (y_unique contained {} classes.".format(
                     y_unique.shape[0]
                 )
             )
+        super().__init__(y_unique, s_unique, y, s)
 
     def init_C(self, y, s):
         n_groups = self.y_unique.shape[0] * self.s_unique.shape[0]

--- a/src/fairgrad/fairness_functions.py
+++ b/src/fairgrad/fairness_functions.py
@@ -1,8 +1,6 @@
 import numpy as np
 import numpy.typing as npt
-from dataclasses import dataclass
 from typing import NamedTuple, Optional
-
 
 def convert(preds):
     if len(preds.shape) == 1:
@@ -22,6 +20,15 @@ class FairnessMeasure:
         self.s_unique = s_unique
         self.init_C(y, s)
         self.init_P(y, s)
+
+    def init_C(self):
+        raise NotImplementedError
+    
+    def init_P(self):
+        raise NotImplementedError
+    
+    def groupwise(self):
+        raise NotImplementedError
 
 
 class EqualizedOdds(FairnessMeasure):
@@ -284,47 +291,46 @@ class DemographicParity(FairnessMeasure):
 
         return groupwise_fairness
 
+NAMES = {
+    "equal_odds": EqualizedOdds,
+    "equal_opportunity": EqualityOpportunity,
+    "accuracy_parity": AccuracyParity,
+    "demographic_parity": DemographicParity,
+}
+    
+def instantiate_fairness(fairness_function, y_train = None, s_train = None, y_desirable = None):
+    if type(fairness_function) == str:
+        if fairness_function not in NAMES.keys():
+            raise NotImplementedError
+        fairness_function = NAMES[fairness_function]
 
-@dataclass
-class FairnessSetupArguments:
-    fairness_function_name: str
-    y_unique: np.asarray
-    s_unique: np.asarray
-    all_train_y: np.asarray
-    all_train_s: np.asarray
-    y_desirable: Optional[np.asarray] = None
+    fairness_class = [cls.__name__ for cls in NAMES.values()]
+    if isinstance(fairness_function, tuple(NAMES.values())):
+        return fairness_function
+    elif isinstance(fairness_function, type) and fairness_function.__name__ in fairness_class:
+        if y_train is None:
+            raise ValueError("y_train is required when using {}.".format(fairness_function.__name__))
+        if s_train is None:
+            raise ValueError("s_train is required when using {}.".format(fairness_function.__name__))
+        
+        y_unique = np.unique(y_train)
+        s_unique = np.unique(s_train)
 
-
-def setup_fairness_function(fairness_setup: FairnessSetupArguments):
-    if fairness_setup.fairness_function_name == "equal_odds":
-        fairness_function = EqualizedOdds(
-            y_unique=fairness_setup.y_unique,
-            s_unique=fairness_setup.s_unique,
-            y=fairness_setup.all_train_y,
-            s=fairness_setup.all_train_s,
-        )
-    elif fairness_setup.fairness_function_name == "equal_opportunity":
-        fairness_function = EqualityOpportunity(
-            y_unique=fairness_setup.y_unique,
-            s_unique=fairness_setup.s_unique,
-            y_desirable=fairness_setup.y_desirable,
-            y=fairness_setup.all_train_y,
-            s=fairness_setup.all_train_s,
-        )
-    elif fairness_setup.fairness_function_name == "accuracy_parity":
-        fairness_function = AccuracyParity(
-            y_unique=fairness_setup.y_unique,
-            s_unique=fairness_setup.s_unique,
-            y=fairness_setup.all_train_y,
-            s=fairness_setup.all_train_s,
-        )
-    elif fairness_setup.fairness_function_name == "demographic_parity":
-        fairness_function = DemographicParity(
-            y_unique=fairness_setup.y_unique,
-            s_unique=fairness_setup.s_unique,
-            y=fairness_setup.all_train_y,
-            s=fairness_setup.all_train_s,
-        )
+        if not np.all(y_unique == np.arange(y_unique.shape[0])):
+            raise ValueError("Targets should be consecutive positive integers: got {} but expected {}.".format(y_unique, np.arange(y_unique.shape[0])))
+        
+        if not np.all(s_unique == np.arange(s_unique.shape[0])):
+            raise ValueError("Sensitive attributes should be consecutive positive integers: got {} but expected {}.".format(s_unqiue, np.arange(s_unique.shape[0])))
+        
+        if fairness_function.__name__ == "EqualityOpportunity":
+            if y_desirable is None:
+                raise ValueError("y_desirable is required when using {}.".format(fairness_function.__name__))
+            if not np.all([(y in y_unique) for y in y_desirable]):
+                raise ValueError("Desirable outcomes should be a subset of possible targets: got ´°but expected a subset of {}.".format(y_desirable, y_unique))
+            
+            return fairness_function(y_unique, s_unique, y_train, s_train, y_desirable) 
+        else:
+            return fairness_function(y_unique, s_unique, y_train, s_train)
     else:
-        raise NotImplementedError
+        raise ValueError("Fairness measure must be either a subclass of {base_class_name} or an instantiated object of a subclass of {base_class_name}.".format(base_class_name=FairnessMeasure.__name__))
     return fairness_function

--- a/src/fairgrad/fairness_functions.py
+++ b/src/fairgrad/fairness_functions.py
@@ -118,13 +118,13 @@ class AccuracyParity(FairnessMeasure):
             )
             self.C[:, j] = np.mean(s == rp)
 
-        self.C = (
-            self.C
-            - np.eye(n_groups)
-            - np.eye(n_groups, k=self.s_unique.shape[0])
-            - np.eye(n_groups, k=-self.s_unique.shape[0])
-        ) / self.y_unique.shape[0]
-
+        for i in range(self.y_unique.shape[0]):
+            self.C = self.C - np.eye(n_groups, k=i*self.s_unique.shape[0])
+            if i != 0:
+                self.C = self.C - np.eye(n_groups, k=-i*self.s_unique.shape[0])
+                
+        self.C = self.C / self.y_unique.shape[0]
+        
     def init_P(self, y, s):
         self.P = np.zeros((self.y_unique.shape[0], self.s_unique.shape[0]))
         for r in self.s_unique:
@@ -143,7 +143,7 @@ class AccuracyParity(FairnessMeasure):
         return groupwise_fairness
 
 
-class EqualityOpportunity:
+class EqualityOpportunity(FairnessMeasure):
     r"""The function implements the accuracy parity fairness function.
     A model :math:`h_θ` is fair for Equality of Opportunity when the probability of predicting the
     correct label is independent of the sensitive attribute for a given subset of labels called the desirable outcomes
@@ -351,7 +351,7 @@ def instantiate_fairness(
                 )
             if not np.all([(y in y_unique) for y in y_desirable]):
                 raise ValueError(
-                    "Desirable outcomes should be a subset of possible targets: got ´°but expected a subset of {}.".format(
+                    "Desirable outcomes should be a subset of possible targets: got {} but expected a subset of {}.".format(
                         y_desirable, y_unique
                     )
                 )

--- a/src/fairgrad/torch/cross_entropy.py
+++ b/src/fairgrad/torch/cross_entropy.py
@@ -15,25 +15,11 @@ from typing import Callable, Optional, Union, Type
 
 
 class FairnessLoss(nn.modules.loss._Loss):
-    r"""This is an extension of the CrossEntropyLoss provided by pytorch. Please check pytorch documentation
-    for understanding the cross entropy loss. Here, we augment the cross entropy to enforce fairness. The
-    exact algorithm can be found in Fairgrad paper <https://arxiv.org/abs/2206.10923>.
+    r"""This is an extension of the losses provided by pytorch. Here, we augment the losses to enforce fairness. The
+    exact algorithm can be found in the Fairgrad paper <https://arxiv.org/abs/2206.10923>.
 
     Args:
-        weight (Tensor, optional): a manual rescaling weight given to each class.
-            If given, has to be a Tensor of size `C`
-        size_average (bool, optional): Deprecated (see :attr:`reduction`). By default,
-            the losses are averaged over each loss element in the batch. Note that for
-            some losses, there are multiple elements per sample. If the field :attr:`size_average`
-            is set to ``False``, the losses are instead summed for each minibatch. Ignored
-            when reduce is ``False``. Default: ``True``
-        ignore_index (int, optional): Specifies a target value that is ignored
-            and does not contribute to the input gradient. When :attr:`size_average` is
-            ``True``, the loss is averaged over non-ignored targets.
-        reduce (bool, optional): Deprecated (see :attr:`reduction`). By default, the
-            losses are averaged or summed over observations for each minibatch depending
-            on :attr:`size_average`. When :attr:`reduce` is ``False``, returns a loss per
-            batch element instead and ignores :attr:`size_average`. Default: ``True``
+        base_loss_class (nn.modules.loss._Loss): Specifies the base loss as a proper base loss.
         reduction (string, optional): Specifies the reduction to apply to the output:
             ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will
             be applied, ``'mean'``: the weighted mean of the output is taken,
@@ -41,13 +27,16 @@ class FairnessLoss(nn.modules.loss._Loss):
             and :attr:`reduce` are in the process of being deprecated, and in
             the meantime, specifying either of those two args will override
             :attr:`reduction`. Default: ``'mean'``
+        fairness_measure (string, FairnessMeasure): Currently supported are "equal_odds", "equal_opportunity", "demographic_parity", and "accuracy_parity".
         y_train (np.asarray[int], Tensor, optional): All train example's corresponding label
         s_train (np.asarray[int], Tensor, optional): All train example's corresponding sensitive attribute. This means if there
             are 2 sensitive attributes, with each of them being binary. For instance gender - (male and female) and
             age (above 45, below 45). Total unique sentive attributes are 4.
-        fairness_measure (string): Currently we support "equal_odds", "equal_opportunity", and "accuracy_parity".
+        y_desirable (np.asarray[int], Tensor, optional): All desirable labels, only used with equality of opportunity.
         epsilon (float, optional): The slack which is allowed for the final fairness level.
         fairness_rate (float, optional): Parameter which intertwines current fairness weights with sum of previous fairness rates.
+        **kwargs: Arbitrary keyword arguments passed to base_loss_class upon instantiation. Using is at your own risk as it might result in unexpected behaviours.
+
 
 
 
@@ -56,7 +45,7 @@ class FairnessLoss(nn.modules.loss._Loss):
         >>> input = torch.randn(10, 5, requires_grad=True)
         >>> target = torch.empty(10, dtype=torch.long).random_(2)
         >>> s = torch.empty(10, dtype=torch.long).random_(2) # protected attribute
-        >>> loss = CrossEntropyLoss(y_train = target, s_train = s, fairness_measure = 'equal_odds')
+        >>> loss = FairnessLoss(nn.CrossEntropyLoss,y_train = target, s_train = s, fairness_measure = 'equal_odds')
         >>> output = loss(input, target, s, mode='train')
         >>> output.backward()
     """
@@ -207,5 +196,56 @@ class FairnessLoss(nn.modules.loss._Loss):
 
 
 class CrossEntropyLoss(FairnessLoss):
-    def __init__(self, **kwargs):
-        super().__init__(nn.CrossEntropyLoss, **kwargs)
+    r"""This is an extension of the CrossEntropyLoss provided by pytorch. Please check pytorch documentation
+    for understanding the cross entropy loss.
+
+    Args:
+        reduction (string, optional): Specifies the reduction to apply to the output:
+            ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will
+            be applied, ``'mean'``: the weighted mean of the output is taken,
+            ``'sum'``: the output will be summed. Note: :attr:`size_average`
+            and :attr:`reduce` are in the process of being deprecated, and in
+            the meantime, specifying either of those two args will override
+            :attr:`reduction`. Default: ``'mean'``
+        fairness_measure (string, FairnessMeasure): Currently supported are "equal_odds", "equal_opportunity", "demographic_parity", and "accuracy_parity".
+        y_train (np.asarray[int], Tensor, optional): All train example's corresponding label
+        s_train (np.asarray[int], Tensor, optional): All train example's corresponding sensitive attribute. This means if there
+            are 2 sensitive attributes, with each of them being binary. For instance gender - (male and female) and
+            age (above 45, below 45). Total unique sentive attributes are 4.
+        y_desirable (np.asarray[int], Tensor, optional): All desirable labels, only used with equality of opportunity.
+        epsilon (float, optional): The slack which is allowed for the final fairness level.
+        fairness_rate (float, optional): Parameter which intertwines current fairness weights with sum of previous fairness rates.
+        **kwargs: Arbitrary keyword arguments passed to CrossEntropyLoss upon instantiation. Using is at your own risk as it might result in unexpected behaviours.
+
+    Examples::
+
+        >>> input = torch.randn(10, 5, requires_grad=True)
+        >>> target = torch.empty(10, dtype=torch.long).random_(2)
+        >>> s = torch.empty(10, dtype=torch.long).random_(2) # protected attribute
+        >>> loss = CrossEntropyLoss(y_train = target, s_train = s, fairness_measure = 'equal_odds')
+        >>> output = loss(input, target, s, mode='train')
+        >>> output.backward()
+    """
+
+    def __init__(
+        self,
+        reduction: str = "mean",
+        fairness_measure: Optional[Union[str, Type[FairnessMeasure]]] = None,
+        y_train: Optional[Union[npt.NDArray[int], Tensor]] = None,
+        s_train: Optional[Union[npt.NDArray[int], Tensor]] = None,
+        y_desirable: Optional[Union[npt.NDArray[int], Tensor]] = [1],
+        epsilon: Optional[float] = 0.0,
+        fairness_rate: Optional[float] = 0.01,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            nn.CrossEntropyLoss,
+            reduction=reduction,
+            fairness_measure=fairness_measure,
+            y_train=y_train,
+            s_train=s_train,
+            y_desirable=y_desirable,
+            epsilon=epsilon,
+            fairness_rate=fairness_rate,
+            **kwargs,
+        )

--- a/tests/test_fairgrad.py
+++ b/tests/test_fairgrad.py
@@ -1,11 +1,153 @@
+import unittest
+
 import torch
 import numpy as np
 
 # fairgrad imports.
 from fairgrad import __version__
 from fairgrad.torch.cross_entropy import CrossEntropyLoss
+from fairgrad.fairness_functions import *
+    
 
+class TestFairnessMeasures(unittest.TestCase):
+    def test_instantiate_fairness(self):
+        y_train = np.random.randint(5, size=(1000,))
+        s_train = np.random.randint(3, size=(1000,))
+        with self.assertRaises(NotImplementedError):
+            instantiate_fairness("dummy_parity",y_train,s_train)
+            
+        with self.assertRaises(ValueError):
+            instantiate_fairness(22,y_train,s_train)
+            instantiate_fairness(EqualizedOdds,None,s_train)
+            instantiate_fairness(EqualizedOdds,y_train,None)
+            instantiate_fairness(EqualizedOdds,y_train+1,s_train)
+            instantiate_fairness(EqualizedOdds,y_train,s_train+1)
+            instantiate_fairness(EqualityOpportunity,y_train,s_train,None)
+            instantiate_fairness(EqualityOpportunity,y_train,s_train,np.array([0,2,5]))
+            
+        
+    
+    def test_EqualizedOdds(self):
+        y_train = np.random.randint(5, size=(1000,))
+        y_preds = np.random.randint(5, size=(1000,))
+        s_train = np.random.randint(3, size=(1000,))
+        fm = instantiate_fairness(EqualizedOdds,y_train,s_train)
+        groupwise = fm.groupwise(y_preds,y_train,s_train)
+    
+        n_groups = fm.y_unique.shape[0] * fm.s_unique.shape[0]
+        error_rates = np.zeros((n_groups,))
 
+        indices = np.ravel_multi_index(
+            (
+                [l for l in fm.y_unique for r in fm.s_unique],
+                [r for l in fm.y_unique for r in fm.s_unique],
+            ),
+            (fm.y_unique.shape[0], fm.s_unique.shape[0]),
+        )
+
+        for i in indices:
+            l, r = np.unravel_index(
+                i, (fm.y_unique.shape[0], fm.s_unique.shape[0])
+            )
+            error_rates[i] = np.mean((y_train != y_preds)[np.logical_and(y_train == l,s_train == r)])
+            
+        groupwise_C = fm.C.dot(error_rates.reshape(-1,1)) + fm.C0.reshape(-1,1)
+        groupwise_C = groupwise_C.reshape(fm.y_unique.shape[0],fm.s_unique.shape[0])
+
+        self.assertTrue(np.allclose(groupwise,groupwise_C))
+        self.assertTrue(np.allclose(groupwise_C,groupwise))
+
+    def test_EqualiOpportunity(self):
+        y_train = np.random.randint(5, size=(1000,))
+        y_preds = np.random.randint(5, size=(1000,))
+        s_train = np.random.randint(3, size=(1000,))
+        y_desirable = np.array([0,2,3])
+        fm = instantiate_fairness(EqualityOpportunity,y_train,s_train,y_desirable)
+        groupwise = fm.groupwise(y_preds,y_train,s_train)
+
+        n_groups = fm.y_unique.shape[0] * fm.s_unique.shape[0]
+        error_rates = np.zeros((n_groups,))
+
+        indices = np.ravel_multi_index(
+            (
+                [l for l in fm.y_unique for r in fm.s_unique],
+                [r for l in fm.y_unique for r in fm.s_unique],
+            ),
+            (fm.y_unique.shape[0], fm.s_unique.shape[0]),
+        )
+
+        for i in indices:
+            l, r = np.unravel_index(
+                i, (fm.y_unique.shape[0], fm.s_unique.shape[0])
+            )
+            error_rates[i] = np.mean((y_train != y_preds)[np.logical_and(y_train == l,s_train == r)])
+            
+        groupwise_C = fm.C.dot(error_rates.reshape(-1,1)) + fm.C0.reshape(-1,1)
+        groupwise_C = groupwise_C.reshape(fm.y_unique.shape[0],fm.s_unique.shape[0])
+
+        self.assertTrue(np.allclose(groupwise,groupwise_C))
+        self.assertTrue(np.allclose(groupwise_C,groupwise))
+
+    def test_AccuracyParity(self):
+        y_train = np.random.randint(5, size=(1000,))
+        y_preds = np.random.randint(5, size=(1000,))
+        s_train = np.random.randint(3, size=(1000,))
+        fm = instantiate_fairness(AccuracyParity,y_train,s_train)
+        groupwise = fm.groupwise(y_preds,y_train,s_train)
+    
+        n_groups = fm.y_unique.shape[0] * fm.s_unique.shape[0]
+        error_rates = np.zeros((n_groups,))
+
+        indices = np.ravel_multi_index(
+            (
+                [l for l in fm.y_unique for r in fm.s_unique],
+                [r for l in fm.y_unique for r in fm.s_unique],
+            ),
+            (fm.y_unique.shape[0], fm.s_unique.shape[0]),
+        )
+
+        for i in indices:
+            l, r = np.unravel_index(
+                i, (fm.y_unique.shape[0], fm.s_unique.shape[0])
+            )
+            error_rates[i] = np.mean((y_train != y_preds)[s_train == r])
+
+        groupwise_C = fm.C.dot(error_rates.reshape(-1,1)) + fm.C0.reshape(-1,1)
+        groupwise_C = groupwise_C.reshape(fm.y_unique.shape[0],fm.s_unique.shape[0])
+        
+        self.assertTrue(np.allclose(groupwise,groupwise_C))
+        self.assertTrue(np.allclose(groupwise_C,groupwise))
+
+    def test_DemographicParity(self):
+        y_train = np.random.randint(2, size=(1000,))
+        y_preds = np.random.randint(2, size=(1000,))
+        s_train = np.random.randint(3, size=(1000,))
+        fm = instantiate_fairness(DemographicParity,y_train,s_train)
+        groupwise = fm.groupwise(y_preds,y_train,s_train)
+    
+        n_groups = fm.y_unique.shape[0] * fm.s_unique.shape[0]
+        error_rates = np.zeros((n_groups,))
+
+        indices = np.ravel_multi_index(
+            (
+                [l for l in fm.y_unique for r in fm.s_unique],
+                [r for l in fm.y_unique for r in fm.s_unique],
+            ),
+            (fm.y_unique.shape[0], fm.s_unique.shape[0]),
+        )
+
+        for i in indices:
+            l, r = np.unravel_index(
+                i, (fm.y_unique.shape[0], fm.s_unique.shape[0])
+            )
+            error_rates[i] = np.mean((y_train != y_preds)[np.logical_and(y_train == l,s_train == r)])
+            
+        groupwise_C = fm.C.dot(error_rates.reshape(-1,1)) + fm.C0.reshape(-1,1)
+        groupwise_C = groupwise_C.reshape(fm.y_unique.shape[0],fm.s_unique.shape[0])
+
+        self.assertTrue(np.allclose(groupwise,groupwise_C))
+        self.assertTrue(np.allclose(groupwise_C,groupwise))
+        
 def test_version():
     assert __version__ == "0.1.7"
 


### PR DESCRIPTION
Summary of the backward compatible changes:

- Added support for user-defined Losses by refactoring the way losses are handled. A base class called FairnessLoss that takes a torch loss as an argument has been created. Added a wrapper for CrossEntropyLoss for backward compatibility.
- Added support for user-defined Fairness measures that inherit the FairnessMeasure base class.
- Added basic unittesting for the different fairness functions.

Summary of the non-backward compatible changes:
- Removed the support for the mode parameter in the forward function.

Bug fix:
- Fixed a bug in Accuracy Parity (in the method init_C) when the number of classes was higher than 2.